### PR TITLE
Avoid P3P error message from Google/Yahoo server

### DIFF
--- a/app/webroot/P3P-Policy.xml
+++ b/app/webroot/P3P-Policy.xml
@@ -1,0 +1,7 @@
+<META xmlns="http://www.w3.org/2002/01/P3Pv1">
+ <POLICY-REFERENCES>
+    <POLICY-REF about="/P3P-Policy.xml">
+       <COOKIE-INCLUDE name="*" value="*" domain="*" path="*"/>
+    </POLICY-REF>
+ </POLICY-REFERENCES>
+</META>

--- a/app/webroot/policy.xml
+++ b/app/webroot/policy.xml
@@ -1,0 +1,10 @@
+<META xmlns="http://www.w3.org/2002/01/P3Pv1">
+ <POLICY-REFERENCES>
+  <EXPIRY max-age="172800"/>
+
+    <POLICY-REF about="/P3P-Policy.xml">
+      <INCLUDE>/*</INCLUDE>
+    </POLICY-REF>
+
+ </POLICY-REFERENCES>
+</META>

--- a/app/webroot/proxy.php
+++ b/app/webroot/proxy.php
@@ -5,7 +5,18 @@ function isValidURL($url) {
 }
 
 if(isValidURL($_GET['url'])){
-    echo file_get_contents($_GET['url']);
+    // Création d'un flux
+    $opts = array(
+        'http'=>array(
+        'method'=>"GET",
+        'header'=>"Accept-language: en\r\n" .
+                  "P3P: policyref=\"" . "http://".$_SERVER['HTTP_HOST'] ."/policy.xml\"\r\n"
+      )
+    );
+
+    $context = stream_context_create($opts);
+
+    echo file_get_contents($_GET['url'], false, $context);
 }else{
     echo "Not valid url";
 }


### PR DESCRIPTION
Fix Issue #13 when retrieving Google/Yahoo Rss feeds : avoid P3P error message from Google/Yahoo server.

You'd rather help me to improve such feature by adding a flag parameter to enable or disable the feature.
