### PR TITLE
Added escape call for widget code block

### DIFF
--- a/app/View/Dashboards/view.ctp
+++ b/app/View/Dashboards/view.ctp
@@ -12,7 +12,7 @@ foreach ($dashboard['Dbview'] as $dbview){
     $wid = 'id_'.uniqid();
     $code = str_replace('${wid}', $wid, $dbview['code']);
     $style = $user == null ? 'cursor:auto' : '';
-    echo "<textarea id='code$id' style='display: none;'>$code</textarea>";
+    echo "<textarea id='code$id' style='display: none;'>".htmlentities($code)."</textarea>";
     echo "<div class='well dragbox' id='dragbox_$id' style='z-index: $zid; left: ".$dbview['left']."px; top: ".$dbview['top']."px; width: ".($dbview['width'])."px; height: ".($dbview['height'])."px;'>";
     echo "<div class='header' style='$style'>";
     echo "<span>&nbsp;";


### PR DESCRIPTION
We were seeing some confusion in the browser with id tags because the hidden code was not escaped.
